### PR TITLE
Remove thread lock manager's setup and destroy semantics

### DIFF
--- a/src/parallel/parallel.cpp
+++ b/src/parallel/parallel.cpp
@@ -183,32 +183,6 @@ ParallelRobinHoodHashTable::find(KeyType key)
     // TODO
 }
 
-void
-ParallelRobinHoodHashTable::add_thread_lock_manager()
-{
-    std::thread::id t_id = std::this_thread::get_id();
-    assert(!this->thread_managers_.contains(t_id) &&
-           "thread manager for current thread already exists");
-    this->thread_managers_.emplace(t_id, ThreadManager(this));
-}
-
-void
-ParallelRobinHoodHashTable::remove_thread_lock_manager()
-{
-    std::thread::id t_id = std::this_thread::get_id();
-    assert(this->thread_managers_.contains(t_id) &&
-           "thread manager for current thread DNE");
-    this->thread_managers_.erase(t_id);
-}
-
-/// @brief  Get real bucket index.
-static size_t
-get_real_index(const size_t home, const size_t offset, const size_t capacity)
-{
-    LOG_TRACE("Enter");
-    return (home + offset) % capacity;
-}
-
 std::pair<size_t, bool>
 ParallelRobinHoodHashTable::find_next_index_lock(ThreadManager &manager,
                                                  size_t start_index,
@@ -244,10 +218,8 @@ ParallelRobinHoodHashTable::find_next_index_lock(ThreadManager &manager,
 ThreadManager &
 ParallelRobinHoodHashTable::get_thread_lock_manager()
 {
-    std::thread::id t_id = std::this_thread::get_id();
-    assert(this->thread_managers_.contains(t_id) &&
-           "thread manager for current thread DNE");
-    return this->thread_managers_.at(t_id);
+    static thread_local ThreadManager manager(this);
+    return manager;
 }
 
 bool

--- a/src/parallel/parallel.hpp
+++ b/src/parallel/parallel.hpp
@@ -138,14 +138,6 @@ public:
     std::pair<ValueType, bool>
     find(KeyType key);
 
-    /// Call this when adding a new thread to work on the hash table.
-    void
-    add_thread_lock_manager();
-
-    /// Call this when removing a worker thread that worked on the hash table.
-    void
-    remove_thread_lock_manager();
-
 private:
     std::vector<ParallelBucket> buckets_ = std::vector<ParallelBucket>(1024 + 10);
     std::vector<SegmentLock> segment_locks_;


### PR DESCRIPTION
I made this a separate MR from #13 because then if it doesn't work, we can easily revert it.

See @arctic-marmoset's comments on #13's MR [here](https://github.com/thedavidchu/merry_mem/pull/13#discussion_r1388452293)